### PR TITLE
Fixing a few issues

### DIFF
--- a/pdo-iterator.php
+++ b/pdo-iterator.php
@@ -56,7 +56,7 @@ class TableRows extends RecursiveIteratorIterator {
      */
     public function getBody()
     {
-        $output = '';
+        $this->next();
         while ($this->valid()) {
             echo '<td>' . $this->current() . '</td>';
             $this->next();

--- a/recursive-directory-iterator.php
+++ b/recursive-directory-iterator.php
@@ -10,7 +10,7 @@ $files = new RecursiveIteratorIterator(
 // iterate over all files from the child directory "directory-iterator-example"
 foreach ($files as $file) {
     // skip over dots ("." and "..")
-    if (!$file->isDot()) {
+    if (!$files->isDot()) {
         // example of the 
         echo $file->getRealPath() . PHP_EOL;
     }


### PR DESCRIPTION
First, thanks for this examples. I have found some issues in some files.

Using php 5.4 with default development config `.ini`

**pdo-iterator.php**
- The method display an `Array to String convertion` notice if iterator wasn't moved to first position.
- Also remove unused $output variable.

**recursive-directory-iterator.php**
- `isDot()` is a [`DirectoryIterator`](http://php.net/manual/en/class.splfileinfo.php) method ($files) and not a [`SplFileInfo`](http://php.net/manual/en/class.directoryiterator.php) method ($file) :
